### PR TITLE
KA-453 Distinguish badges for master and develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[![Build Status](https://travis-ci.org/Kentico/kentico-cloud-docs-search.svg?branch=master)](https://travis-ci.org/Kentico/kentico-cloud-docs-search)
-[![codebeat badge](https://codebeat.co/badges/3a18e54e-e817-475a-aa54-56753db021af)](https://codebeat.co/projects/github-com-kentico-kentico-cloud-docs-search-master)
+| [master](https://github.com/Kentico/kentico-cloud-docs-search/tree/master) | [develop](https://github.com/Kentico/kentico-cloud-docs-search/tree/develop) |
+|:---:|:---:|
+| [![Build Status](https://travis-ci.org/Kentico/kentico-cloud-docs-search.svg?branch=master)](https://travis-ci.org/Kentico/kentico-cloud-docs-search/branches) [![codebeat badge](https://codebeat.co/badges/3a18e54e-e817-475a-aa54-56753db021af)](https://codebeat.co/projects/github-com-kentico-kentico-cloud-docs-search-master) | [![Build Status](https://travis-ci.org/Kentico/kentico-cloud-docs-search.svg?branch=develop)](https://travis-ci.org/Kentico/kentico-cloud-docs-search/branches) [![codebeat badge](https://codebeat.co/badges/b7154b94-4a70-42ad-aa9f-6b8851c8d17d)](https://codebeat.co/projects/github-com-kentico-kentico-cloud-docs-search-develop) |
+
 
 # kentico-cloud-docs-search
 Kentico Cloud documentation search service


### PR DESCRIPTION
CodeBeat for `develop` branch added and badges for both `master` and `develop` displayed together.