### PR TITLE
KA-505 Rework initialization trigger from Event Grid to HTTP

### DIFF
--- a/kcd-search-service-initialize/function.json
+++ b/kcd-search-service-initialize/function.json
@@ -2,9 +2,19 @@
     "disabled": false,
     "bindings": [
       {
-        "type": "eventGridTrigger",
-        "name": "eventGridEvent",
-        "direction": "in"
+        "authLevel": "function",
+        "type": "httpTrigger",
+        "direction": "in",
+        "name": "req",
+        "methods": [
+          "get",
+          "post"
+        ]
+      },
+      {
+        "type": "http",
+        "direction": "out",
+        "name": "res"
       }
     ]
   }

--- a/kcd-search-service-initialize/index.js
+++ b/kcd-search-service-initialize/index.js
@@ -1,15 +1,12 @@
 const indexers = require('../shared/searchIndexers');
 const { setupConfiguration } = require('../shared/external/configuration');
 
-function validateEvent(event) {
-    return event.subject === 'initialize';
-}
+module.exports = async (context, request) => {
+    setupConfiguration(request.query.test);
+    await indexers.reindexAllArticles();
 
-module.exports = async (context, eventGridEvent) => {
-    if (validateEvent(eventGridEvent)) {
-        setupConfiguration(eventGridEvent.isTest);
-        await indexers.reindexAllArticles();
-    } else {
-        throw new Error('Validation failed. Unsupported event.');
-    }
+    context.res = {
+        status: 200,
+        body: 'Initialization successful'
+    };
 };

--- a/kcd-search-service-update/index.js
+++ b/kcd-search-service-update/index.js
@@ -10,7 +10,7 @@ function validateEvent(event) {
 
 module.exports = async (context, eventGridEvent) => {
     if (validateEvent(eventGridEvent)) {
-        setupConfiguration(eventGridEvent.isTest);
+        setupConfiguration(eventGridEvent.test);
         const codenames = getCodenamesOfItems(eventGridEvent.data.items, 'article');
         await indexers.reindexSpecificArticles(codenames);
     } else {


### PR DESCRIPTION
### Motivation

I reworked the initialize function to use HTTP trigger instead of Event Grid trigger (KA-505).

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
