### PR TITLE
Ka 512 support for content chunk content type

### DIFF
--- a/shared/utils/itemRecordsCreator.js
+++ b/shared/utils/itemRecordsCreator.js
@@ -15,7 +15,10 @@ function createItemRecords(item, textToIndex) {
         if (singleHeadingContent.includes('<callout>')) {
             indexContentSplitByCallouts(singleHeadingContent, heading, item);
         } else {
-            addItemRecord(removeMarkdown(singleHeadingContent).trim(), heading, item);
+            const content = removeMarkdown(singleHeadingContent).trim();
+            if (isNonEmpty(content)) {
+                addItemRecord(content, heading, item);
+            }
         }
     }
 

--- a/shared/utils/richTextResolver.js
+++ b/shared/utils/richTextResolver.js
@@ -1,11 +1,14 @@
 const removeMarkdown = require('remove-markdown');
 
 function resolveItemInRichText(item) {
-    if (item.system.type === 'callout') {
-        const content = removeMarkdown(item.content.value);
-        return `<callout>${content}</callout>`;
-    } else {
-        return '';
+    switch (item.system.type) {
+        case 'callout':
+            const content = removeMarkdown(item.content.value);
+            return `<callout>${content}</callout>`;
+        case 'content_chunk':
+            return item.content.value;
+        default:
+            return '';
     }
 }
 

--- a/shared/utils/richTextResolver.test.js
+++ b/shared/utils/richTextResolver.test.js
@@ -17,6 +17,19 @@ const calloutItem = {
     }
 };
 
+const contentChunkItem = {
+    system: {
+        id: '43e9af9c-569e-4c55-9025-a468bff5018b',
+        language: 'en-US',
+        codename: 'repeated_content',
+        type: 'content_chunk',
+    },
+    content: {
+        name: 'Content',
+        value: '<h2>Repeated content</h2><p>This content is repeated in several Articles</p>',
+    }
+};
+
 const differentItem = {
     ...calloutItem,
     system: {
@@ -40,6 +53,14 @@ describe('resolveItemInRichText', () => {
         const expectedResult = '';
 
         const actualResult = resolveItemInRichText(differentItem);
+
+        expect(actualResult).toEqual(expectedResult);
+    });
+
+    it('returns value of a content chunk content item', () => {
+        const expectedResult = contentChunkItem.content.value;
+
+        const actualResult = resolveItemInRichText(contentChunkItem);
 
         expect(actualResult).toEqual(expectedResult);
     });


### PR DESCRIPTION
### Motivation

Adds content chunk type support

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Tests are passing
- [ ] Documentation has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Add a content chunk to the article, either introduction or content.
